### PR TITLE
Added new/active links in header

### DIFF
--- a/phpBB/ext/t123/topics/composer.json
+++ b/phpBB/ext/t123/topics/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "t123/topics",
+    "type": "phpbb-extension",
+    "description": "Active & New Topics links",
+    "homepage": "https://github.com/t123/",
+    "version": "0.1.0",
+    "time": "2015-08-21",
+    "license": "AGPL-3.0",
+    "authors": [{
+        "name": "t123",
+        "homepage": "https://github.com/t123/",
+        "role": "Lead Developer"
+   }],
+    "require": {
+        "php": ">=5.3.3",
+        "composer/installers": "~1.0"
+    },
+    "extra": {
+        "display-name": "Active/New Links",
+        "soft-require": {
+            "phpbb/phpbb": ">=3.1.0-RC2,<3.2.*@dev"
+        }
+    }
+}

--- a/phpBB/ext/t123/topics/styles/all/template/event/overall_header_navigation_append.html
+++ b/phpBB/ext/t123/topics/styles/all/template/event/overall_header_navigation_append.html
@@ -1,0 +1,8 @@
+<!-- IF S_USER_LOGGED_IN -->
+<li class="small-icon icon-search-new" role="menuitem" <!-- IF not S_USER_LOGGED_IN -->data-skip-responsive="true"<!-- ELSE -->data-last-responsive="true"<!-- ENDIF -->>
+    <a href="{U_SEARCH_NEW}">{L_SEARCH_NEW}</a>
+</li>
+<!-- ENDIF -->
+<li class="small-icon icon-search-active" role="menuitem">
+    <a href="{U_SEARCH_ACTIVE_TOPICS}">{L_SEARCH_ACTIVE_TOPICS}</a>
+</li>


### PR DESCRIPTION
Should be fairly safe, you can always disable the extension. Seems to work fine with **we_universal** too.
