### PR TITLE
new extension with blog and wiki buttons on site menu.

### DIFF
--- a/phpBB/ext/button_extension/topics/composer.json
+++ b/phpBB/ext/button_extension/topics/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "button_extension/topics",
+    "type": "phpbb-extension",
+    "description": "Active & New Topics, wiki and Blog links. Based on t123 extension.",
+    "homepage": "https://github.com/egrapa/",
+    "version": "0.1.0",
+    "time": "2018-08-06",
+    "license": "AGPL-3.0",
+    "authors": [{
+        "name": "egrapa",
+        "homepage": "https://github.com/egrapa/",
+        "role": "Lead Developer"
+   }],
+    "require": {
+        "php": ">=5.3.3",
+        "composer/installers": "~1.0"
+    },
+    "extra": {
+        "display-name": "Active/New/Blog/Wiki Links",
+        "soft-require": {
+            "phpbb/phpbb": ">=3.1.0-RC2,<3.2.*@dev"
+        }
+    }
+}

--- a/phpBB/ext/button_extension/topics/styles/all/template/event/overall_header_navigation_append.html
+++ b/phpBB/ext/button_extension/topics/styles/all/template/event/overall_header_navigation_append.html
@@ -1,0 +1,14 @@
+<!-- IF S_USER_LOGGED_IN -->
+<li class="small-icon icon-search-new" role="menuitem" <!-- IF not S_USER_LOGGED_IN -->data-skip-responsive="true"<!-- ELSE -->data-last-responsive="true"<!-- ENDIF -->>
+    <a href="{U_SEARCH_NEW}">{L_SEARCH_NEW}</a>
+</li>
+<!-- ENDIF -->
+<li class="small-icon icon-search-active" role="menuitem">
+    <a href="{U_SEARCH_ACTIVE_TOPICS}">{L_SEARCH_ACTIVE_TOPICS}</a>
+</li>
+<li class="small-icon icon-search-active" role="menuitem">
+    <a href="http://www.language-learners.org">Blog</a>
+</li>
+<li class="small-icon icon-search-active" role="menuitem">
+    <a href="http://learnanylanguage.wikia.com/wiki/Learn_Any_Language">Wiki</a>
+</li>


### PR DESCRIPTION
Extension to add blog and wiki buttons. Disable existing t123 extension and enable this one and purge cache. Tested on Digi, prosilver and we_universal styles.  